### PR TITLE
Ref. #162 | feat: padroniza HTTP de Image

### DIFF
--- a/backend/src/main/java/com/PIEC/ImobLink/Controllers/ImageController.java
+++ b/backend/src/main/java/com/PIEC/ImobLink/Controllers/ImageController.java
@@ -2,8 +2,9 @@ package com.PIEC.ImobLink.Controllers;
 
 import com.PIEC.ImobLink.DTOs.ImageResponse;
 import com.PIEC.ImobLink.Entitys.Images;
+import com.PIEC.ImobLink.Response.ApiResponse;
+import com.PIEC.ImobLink.Response.ResponseUtil;
 import com.PIEC.ImobLink.Services.ImageService;
-import io.jsonwebtoken.io.IOException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -13,6 +14,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 @RestController
@@ -27,16 +29,11 @@ public class ImageController {
             description = "Permite salvar endereços de imagens diretamente na db (mais utilizado para testes)"
     )
     @PostMapping
-    public ResponseEntity<String> saveImage(@RequestParam("image") MultipartFile image, Authentication auth) throws IOException {
-        try{
-            Images imageResponse = imageService.saveImage(image, auth);
-            if(imageResponse != null) {
-                return ResponseEntity.ok("Imagem salvo com sucesso com caminho: " + imageResponse.getFilepath());
-            }
-            return ResponseEntity.badRequest().body("Erro ao salvar imagem");
-        } catch (Exception e){
-            throw new IOException("Erro ao salvar a imagem ou ao tentar autenticar o usuário: " + e.getMessage() + " tente novamente");
-        }
+    public ResponseEntity<ApiResponse<Images>> saveImage(@RequestParam("image") MultipartFile image, Authentication auth) throws java.io.IOException {
+        Images imageResponse = imageService.saveImage(image, auth);
+        return ResponseUtil.created("Imagem salva com sucesso com caminho: " + imageResponse.getFilepath(),
+                imageResponse
+                );
     }
 
     @Operation(
@@ -46,11 +43,7 @@ public class ImageController {
     @SecurityRequirement(name = "BearerAuth")
     @GetMapping("/{postId}/post/thumb")
     public ResponseEntity<byte[]> getFirstImage(@PathVariable Long postId, Authentication auth) throws IOException {
-        try{
-            return imageService.getFirstImageByPostId(postId, auth);
-        } catch (Exception e){
-            throw new IOException("Erro ao buscar imagem: " + e.getMessage());
-        }
+        return imageService.getFirstImageByPostId(postId, auth);
     }
 
     @Operation(
@@ -59,8 +52,11 @@ public class ImageController {
     )
     @SecurityRequirement(name = "BearerAuth")
     @GetMapping("/{postId}/post/all")
-    public ResponseEntity<List<ImageResponse>> getAllImagesByPostId(@PathVariable Long postId, Authentication auth) throws IOException {
-        return ResponseEntity.ok(imageService.getAllImagesByPostId(postId, auth));
+    public ResponseEntity<ApiResponse<List<ImageResponse>>> getAllImagesByPostId(@PathVariable Long postId, Authentication auth) {
+        return ResponseUtil.ok(
+                "Imagens buscadas com sucesso",
+                imageService.getAllImagesByPostId(postId, auth)
+        );
     }
 
     @Operation(
@@ -69,7 +65,7 @@ public class ImageController {
     )
     @SecurityRequirement(name = "BearerAuth")
     @GetMapping("/get/{imageId}")
-    public ResponseEntity<byte[]> getImageById(@PathVariable Long imageId, Authentication auth) throws IOException, java.io.IOException {
+    public ResponseEntity<byte[]> getImageById(@PathVariable Long imageId, Authentication auth) throws java.io.IOException {
         return imageService.getImageById(imageId, auth);
     }
 }

--- a/backend/src/main/java/com/PIEC/ImobLink/Services/ImageService.java
+++ b/backend/src/main/java/com/PIEC/ImobLink/Services/ImageService.java
@@ -7,7 +7,8 @@ import com.PIEC.ImobLink.Entitys.User;
 import com.PIEC.ImobLink.Repositorys.ImageRepository;
 import com.PIEC.ImobLink.Repositorys.PostRepository;
 import com.PIEC.ImobLink.Repositorys.UserRepository;
-import io.jsonwebtoken.io.IOException;
+import com.PIEC.ImobLink.Response.ApiResponse;
+import com.PIEC.ImobLink.Response.ResponseUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -21,9 +22,11 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 
 @Service
@@ -34,7 +37,7 @@ public class ImageService {
     private final PostRepository postRepository;
 
     //Remover exceptions de PostController e PostService relacionados assim que refatorado
-    public Images saveImage(MultipartFile file, Authentication auth) throws IOException, java.io.IOException {
+    public Images saveImage(MultipartFile file, Authentication auth) throws java.io.IOException {
         String email = auth.getName();
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException(email));
@@ -49,16 +52,13 @@ public class ImageService {
         image.setFilepath(filePath);
         image.setContentType(file.getContentType());
         image.setUser(user);
-        try {
-            imageRepository.save(image);
-        } catch (IOException e) {
-            throw new IOException("Erro ao salvar a imagem: " + e.getMessage());
-        }
+
+        imageRepository.save(image);
 
         return image;
     }
 
-    public Images saveProfileImage(MultipartFile file, Authentication auth) throws IOException, java.io.IOException {
+    public Images saveProfileImage(MultipartFile file, Authentication auth) throws java.io.IOException {
         String email = auth.getName();
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException(email));
@@ -73,39 +73,33 @@ public class ImageService {
         image.setFilepath(filePath);
         image.setContentType(file.getContentType());
         image.setUser(user);
-        try {
-            imageRepository.save(image);
-            user.setImageProfileId(image.getId());
-            userRepository.save(user);
-        } catch (IOException e) {
-            throw new IOException("Erro ao salvar a imagem: " + e.getMessage());
-        }
+
+        imageRepository.save(image);
+        user.setImageProfileId(image.getId());
+        userRepository.save(user);
 
         return image;
     }
 
     public ResponseEntity<byte[]> getFirstImageByPostId(@PathVariable Long postId, Authentication auth) throws java.io.IOException {
         userRepository.findByEmail(auth.getName()).orElseThrow(() -> new UsernameNotFoundException(auth.getName()));
-        try{
-            Post post = postRepository.getPostById(postId);
-            List<Images> images = post.getImages();
 
-            Images image = images.getFirst();
+        Post post = postRepository.getPostById(postId);
+        List<Images> images = post.getImages();
 
-            File file = new File(image.getFilepath());
-            byte[] imageBytes = Files.readAllBytes(file.toPath());
+        Images image = images.getFirst();
 
-            HttpHeaders headers = new HttpHeaders();
-            headers.setContentType(MediaType.IMAGE_JPEG);
-            headers.setContentLength(imageBytes.length);
+        File file = new File(image.getFilepath());
+        byte[] imageBytes = Files.readAllBytes(file.toPath());
 
-            return new ResponseEntity<>(imageBytes, headers, HttpStatus.OK);
-        } catch (ResponseStatusException e) {
-            throw new IOException("Erro ao buscar imagem: " + e.getMessage());
-        }
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.IMAGE_JPEG);
+        headers.setContentLength(imageBytes.length);
+
+        return new ResponseEntity<>(imageBytes, headers, HttpStatus.OK);
     }
 
-    public List<ImageResponse> getAllImagesByPostId(@PathVariable Long postId, Authentication auth) throws IOException {
+    public List<ImageResponse> getAllImagesByPostId(@PathVariable Long postId, Authentication auth) {
         String email = auth.getName();
         userRepository.findByEmail(email).orElseThrow(() -> new UsernameNotFoundException(email));
         Post post = postRepository.findById(postId).orElseThrow(() -> new UsernameNotFoundException(auth.getName()));
@@ -115,14 +109,14 @@ public class ImageService {
                 .toList();
     }
 
-    public ResponseEntity<byte[]> getImageById(@PathVariable Long imageId, Authentication auth) throws IOException, java.io.IOException {
+    public ResponseEntity<byte[]> getImageById(@PathVariable Long imageId, Authentication auth) throws IOException {
         String email = auth.getName();
         userRepository.findByEmail(email).orElseThrow(() -> new UsernameNotFoundException(email));
-        Images image = imageRepository.findById(imageId).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Imagem não encontrada"));
+        Images image = imageRepository.findById(imageId).orElseThrow(() -> new NoSuchElementException(String.valueOf(imageId)));
 
         File file = new File(image.getFilepath());
         if (!file.exists()) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Arquivo não encontrado");
+            throw new NoSuchElementException(String.valueOf(String.valueOf(file)));
         }
 
         byte[] imageBytes = Files.readAllBytes(file.toPath());


### PR DESCRIPTION
- Põe código do ImageController dentro do padrão
- Corrige exceções propagadas no ImageService

OBS: não foi possível pôr as funções de carregamento de imagens dentro do padrão esperado, então as funções que retornam bytes seguem sendo de ReponseEntity convencionais 